### PR TITLE
gscreen -fix homing error do to joint mode

### DIFF
--- a/src/emc/usr_intf/gscreen/emc_interface.py
+++ b/src/emc/usr_intf/gscreen/emc_interface.py
@@ -76,21 +76,25 @@ class emc_control:
         def home_all(self, b):
                 if self.masked: return
                 self.emccommand.mode(self.emc.MODE_MANUAL)
+                self.emccommand.teleop_enable(False)
                 self.emccommand.home(-1)
 
         def unhome_all(self, b):
                 if self.masked: return
                 self.emccommand.mode(self.emc.MODE_MANUAL)
+                self.emccommand.teleop_enable(False)
                 self.emccommand.unhome(-1)
 
         def home_selected(self, axis):
                 if self.masked: return
                 self.emccommand.mode(self.emc.MODE_MANUAL)
+                self.emccommand.teleop_enable(False)
                 self.emccommand.home(axis)
 
         def unhome_selected(self, axis):
                 if self.masked: return
                 self.emccommand.mode(self.emc.MODE_MANUAL)
+                self.emccommand.teleop_enable(False)
                 self.emccommand.unhome(axis)
 
         def jogging(self, b):


### PR DESCRIPTION
needed to set teleop mode off.
it would home the first time right after loading - not after.